### PR TITLE
Improve README's instruction and .env clarity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,36 @@
 ###> symfony/framework-bundle ###
 
-APP_ENV=
-APP_SECRET=
+# Le mode d'environnement de l'application. Peut être soit "dev", soit "prod"
+APP_ENV="dev/prod"
+# L'app secret, qui est une chaine de caractère aléatoire. Vous pouvez utiliser un générateur de mot de passe pour remplir ce champs
+APP_SECRET="abcd1234"
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 
 ###< symfony/framework-bundle ###
 ###> doctrine/mongodb-odm-bundle ###
 
-MONGODB_URL=
-MONGODB_DB=
+# L'URI de la base de données MongoDB (la même que le bot Swan)
+MONGODB_URL="mongodb://localhost:27017/swan"
+# Le nom de la base de données MongoDB
+MONGODB_DB="swan"
+# Laisser vide
+DATABASE_URL=""
 
 ###< doctrine/mongodb-odm-bundle ###
 ###> sentry/sentry-symfony ###
 
-SENTRY_DSN=
+# Votre Token Sentry
+SENTRY_DSN=""
 
 ###< sentry/sentry-symfony ###
 
-OAUTH_DISCORD_CLIENT_ID=
-OAUTH_DISCORD_CLIENT_SECRET=
+# L'ID du module OAUTH de votre client
+OAUTH_DISCORD_CLIENT_ID=""
+# Le "secret" de votre client
+OAUTH_DISCORD_CLIENT_SECRET=""
 
-DISCORD_GUILD=
-DISCORD_SWAN_TOKEN=
+# L'ID de la guilde que vous souhaitez monitorer
+DISCORD_GUILD=""
+# Le token de votre bot.
+DISCORD_SWAN_TOKEN=""

--- a/README.md
+++ b/README.md
@@ -7,13 +7,19 @@ $<p align="center"><img width=400px src="https://skript-mc.fr/assets/images/logo
 [![Maintainability](https://api.codeclimate.com/v1/badges/83ba962d1237ac5048c1/maintainability)](https://codeclimate.com/github/Romitou/SwanDashboard/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/83ba962d1237ac5048c1/test_coverage)](https://codeclimate.com/github/Romitou/SwanDashboard/test_coverage) ![GitHub](https://img.shields.io/github/license/Romitou/SwanDashboard)
 
 ## 🚀 Installation
+
 - Installez [PHP 7.4+](https://www.php.net/downloads) & [Composer](https://getcomposer.org/) sur votre machine ;
-- Installez [MongoDB PHP Driver](https://docs.mongodb.com/drivers/php) via PECL. N'oubliez pas d'ajouter `extension=mongodb.so` dans votre `php.ini` ;
+- Installez [MongoDB PHP Driver](https://docs.mongodb.com/drivers/php) via PECL, avec `sudo pecl install mongodb`. N'oubliez pas d'ajouter `extension=mongodb.so` dans votre `php.ini` ;
 - Téléchargez la [dernière version stable](https://github.com/Romitou/SwanDashboard/releases/latest) ou clonez ce dépôt pour tester les dernières modifications ;
-- Exécutez la commande `composer install` pour installer les modules nécessaires ; 
+- Renommez `.env.example` en `.env`, et remplissez les champs comme indiqué par les commentaires dans le fichier ;
+- Exécutez la commande `yarn` pour installer les modules JavaScript nécessaires. Si la commande `yarn` n'a pas été trouvée, faites `npm i -g yarn` et recommencez cette étape ;
+- Exécutez la commande `composer install` pour installer les modules nécessaires. Si la commande `composer` n'a pas été trouvée, [installez composer](https://getcomposer.org/doc/00-intro.md) ;
+- Si vous souhaitez utiliser le serveur de symfony, [installez-le](https://symfony.com/download) ;
+- Sur le portail des développeurs discord, dans votre application, cliquez sur *OAuth2* dans la barre latérale. Ajoutez cette redirection `http://127.0.0.1:8000/login/authenticate` ;
 - C'est parti ! Mettez en place un serveur web (ou `symfony server:start` en développement) et connectez-vous.
 
 ## 🔍 Rapport de bug et suggestions
+
 - 🐛 Vous avez aperçu un bug lorsque vous utilisez Swan Dashboard ?
 - 💡 Vous avez une idée ou une suggestion ?
 - 💬 Vous souhaitez nous faire part de quelque chose ?
@@ -21,13 +27,13 @@ $<p align="center"><img width=400px src="https://skript-mc.fr/assets/images/logo
 Vous pouvez vous rendre dans le [menu des issues](https://github.com/Romitou/SwanDashboard/issues) et en créer une ; nous y jetterons un œil dès que possible !
 
 ## 🔨 Développement et contributions
-Nos Pull Request sont ouvertes à toute contribution ! Vous pouvez [créer un fork](https://github.com/Romitou/SwanDashboard/fork) (= une copie) de ce dépôt et y faire vos modifications. Voici quelques informations utiles avant de créer une Pull Request :
 
-- 🏷️ Créez votre PR vers la branche `dev` uniquement
-- 📦 Ajoutez le moins de dépendance possible
-
+Nos Pull Request sont ouvertes à toute contribution ! Vous pouvez [créer un fork](https://github.com/Romitou/SwanDashboard/fork) (= une copie) de ce dépôt et y faire vos modifications. Veillez à ajoutez le moins de dépendances possibles.\
 N'hésitez pas à venir discuter et tester les nouveautés sur notre [Discord de développement](https://discord.com/njSgX3w) !
 
+
 ## 🙏 Merci
+
 #### 👥 Développeur
+
 - [Romitou](https://github.com/Romitou) (Romitou#9685)


### PR DESCRIPTION
Amélioration du guide d'installation dans le README en y ajoutant de nombreuses étapes nécessaires.
J'ai également mis à jour le fichier .env.example en y ajoutant des commentaires et des valeurs par défaut pour le rendre plus facile à remplir.

*j'ai aussi supprimé l'annotation qui disait de faire sa PR vers `dev` vu qu'il n'y a pas de branche `dev`*