### PR TITLE
💄 Fix button style on Safari

### DIFF
--- a/templates/history.html.twig
+++ b/templates/history.html.twig
@@ -106,8 +106,8 @@
                                 </div>
                             </div>
                             <div>
-                                <button type="button" class="btn btn-warning"><i class="fas fa-comment-slash"></i> Sanctionner</button>
-                                <a type="button" class="btn btn-info" target="_blank" rel="noopener noreferrer" href="{{ message.channel.id|discordLink(message.messageId) }}" {{ message.newContent is empty ? 'disabled' }}><i class="fas fa-external-link-alt"></i> Voir sur Discord</a>
+                                <button class="btn btn-warning"><i class="fas fa-comment-slash"></i> Sanctionner</button>
+                                <a class="btn btn-info" target="_blank" rel="noopener noreferrer" href="{{ message.channel.id|discordLink(message.messageId) }}" {{ message.newContent is empty ? 'disabled' }}><i class="fas fa-external-link-alt"></i> Voir sur Discord</a>
                             </div>
                         {% else %}
                             {% if app.request.attributes.get('_route') == 'history' %}

--- a/templates/layouts/panel.html.twig
+++ b/templates/layouts/panel.html.twig
@@ -107,12 +107,12 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="exampleModalLabel">Êtes-vous sûr de vouloir vous déconnecter ?</h5>
-                    <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                    <button class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">×</span>
                     </button>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-secondary" type="button" data-dismiss="modal">Annuler</button>
+                    <button class="btn btn-secondary" data-dismiss="modal">Annuler</button>
                     <a class="btn btn-primary" href="{{ path('logout') }}">Déconnexion</a>
                 </div>
             </div>

--- a/templates/messages/admin.html.twig
+++ b/templates/messages/admin.html.twig
@@ -54,7 +54,7 @@
                                             {{ request.reviewer.username ?? '' }}
                                         </td>
                                         <td>
-                                            <a href="{{ path('messages:view', { messageId: request.id }) }}" type="button" class="btn btn-info"><i class="fas fa-eye"></i></a>
+                                            <a href="{{ path('messages:view', { messageId: request.id }) }}" class="btn btn-info"><i class="fas fa-eye"></i></a>
                                         </td>
                                     </tr>
                                 {% endfor %}

--- a/templates/messages/edit.html.twig
+++ b/templates/messages/edit.html.twig
@@ -18,7 +18,7 @@
                                 <div class="input-group-prepend">
                                     <span class="input-group-text">Nom</span>
                                 </div>
-                                <input type="text" class="form-control" value="{{ addonPack.name }}" aria-label="Nom" aria-describedby="name" id="name" name="name" onchange="generateDiff()">
+                                <input type="text" class="form-control" value="{{ addonPack.name }}" aria-label="Nom" aria-describedby="name" id="name" name="name" onkeyup="generateDiff()">
                             </div>
                             <div class="dropdown-divider mb-3"></div>
                             <div> {# Don't remove this empty node #}
@@ -26,7 +26,7 @@
                                     {% for alias in addonPack.aliases %}
                                         <div class="form-group mr-2">
                                             <div class="input-group">
-                                                <input type="text" class="form-control" name="aliases[{index}]" value="{{ alias }}" onchange="generateDiff()">
+                                                <input type="text" class="form-control" name="aliases[{index}]" value="{{ alias }}" onkeyup="generateDiff()">
                                                 <div class="input-group-append">
                                                     <button class="btn btn-outline-danger link-remove" type="button">
                                                         <i class="fas fa-times"></i>
@@ -96,10 +96,12 @@
                 document.querySelectorAll('.link-remove').forEach((el) => el.addEventListener('click', () => {
                     const element = el.parentNode.parentNode;
                     element.parentNode.removeChild(element);
+
+                    generateDiff();
                 }));
 
                 document.getElementById('addAliasButton').addEventListener('click', () => {
-                    const input = '<div class="input-group"> <input type="text" class="form-control" name="aliases[{index}]" onchange="generateDiff()" <div class="input-group-append"> <button class="btn btn-outline-danger link-remove" type="button"> <i class="fas fa-times"></i> </button> </div> </div>'
+                    const input = '<div class="input-group"> <input type="text" class="form-control" name="aliases[{index}]" onkeyup="generateDiff()" <div class="input-group-append"> <button class="btn btn-outline-danger link-remove" type="button"> <i class="fas fa-times"></i> </button> </div> </div>'
                     const newElement = document.createElement('div');
 
                     newElement.className = 'form-group mr-2';
@@ -111,6 +113,8 @@
                     linkRemove.addEventListener('click', () => {
                         const element = linkRemove.parentNode.parentNode;
                         element.parentNode.removeChild(element);
+
+                        generateDiff();
                     });
 
                 });

--- a/templates/messages/edit.html.twig
+++ b/templates/messages/edit.html.twig
@@ -38,7 +38,7 @@
                                 </div>
                             </div>
                             <div class="mb-3">
-                                <button type="button" id="addAliasButton" class="btn btn-sm btn-success">
+                                <button id="addAliasButton" class="btn btn-sm btn-success">
                                     <i class="fas fa-plus"></i> Ajouter un alias
                                 </button>
                             </div>

--- a/templates/messages/home.html.twig
+++ b/templates/messages/home.html.twig
@@ -75,7 +75,7 @@
                                                     {% endif %}
                                                 </td>
                                                 <td>
-                                                    <a href="{{ path('messages:view', { messageId: request.id }) }}" type="button" class="btn btn-info"><i class="fas fa-eye"></i></a>
+                                                    <a href="{{ path('messages:view', { messageId: request.id }) }}" class="btn btn-info"><i class="fas fa-eye"></i></a>
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/templates/messages/home.html.twig
+++ b/templates/messages/home.html.twig
@@ -9,13 +9,10 @@
                     <div class="card-header">
                         <ul class="nav nav-tabs card-header-tabs">
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ path('messages:auto') }}">Messages rapides</a>
+                                <a class="nav-link active" href="{{ path('messages') }}">Accueil</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ path('messages:error') }}">Détails erreurs</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ path('messages:addonpack') }}">Packs d'add-ons</a>
+                                <a class="nav-link" href="{{ path('messages:auto') }}">Messages</a>
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('messages:new') }}"><i class="fas fa-pen"></i> Nouveau message</a>

--- a/templates/messages/list.html.twig
+++ b/templates/messages/list.html.twig
@@ -83,7 +83,7 @@
                                                                     {{ message.content|truncate }}
                                                                 </td>
                                                                 <td>
-                                                                    <a href="{{ path('messages:edit', { messageId: message.id }) }}" type="button" class="btn btn-info"><i class="fas fa-edit"></i></a>
+                                                                    <a href="{{ path('messages:edit', { messageId: message.id }) }}" class="btn btn-info"><i class="fas fa-edit"></i></a>
                                                                 </td>
                                                             </tr>
                                                         {% endfor %}

--- a/templates/messages/list.html.twig
+++ b/templates/messages/list.html.twig
@@ -11,13 +11,10 @@
                     <div class="card-header">
                         <ul class="nav nav-tabs card-header-tabs">
                             <li class="nav-item">
-                                <a class="nav-link {{ app.request.attributes.get('_route') == 'messages:auto' ? 'active' }}" href="{{ path('messages:auto') }}">Messages rapides</a>
+                                <a class="nav-link" href="{{ path('messages') }}">Accueil</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link {{ app.request.attributes.get('_route') == 'messages:error' ? 'active' }}" href="{{ path('messages:error') }}">Détails erreurs</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link {{ app.request.attributes.get('_route') == 'messages:addonpack' ? 'active' }}" href="{{ path('messages:addonpack') }}">Packs d'add-ons</a>
+                                <a class="nav-link active" href="{{ path('messages:auto') }}">Messages</a>
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ path('messages:new') }}"><i class="fas fa-pen"></i> Nouveau message</a>
@@ -30,35 +27,77 @@
                         </ul>
                     </div>
                     <div class="card-body">
-                        <div class="table-responsive">
-                            <table class="table">
-                                <thead>
-                                <tr>
-                                    <th scope="col">Nom</th>
-                                    <th scope="col">Aliases</th>
-                                    <th scope="col">Aperçu du contenu</th>
-                                    <th scope="col">Actions</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                {% for message in messages %}
-                                    <tr>
-                                        <td>
-                                            {{ message.name }}
-                                        </td>
-                                        <td>
-                                            {{ message.aliases|join(', ') }}
-                                        </td>
-                                        <td>
-                                            {{ message.content|truncate }}
-                                        </td>
-                                        <td>
-                                            <a href="{{ path('messages:edit', { messageId: message.id }) }}" type="button" class="btn btn-info"><i class="fas fa-edit"></i></a>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
+                        <div class="row">
+                            <div class="col-lg-2">
+                                <div class="nav flex-column nav-pills" aria-orientation="vertical">
+                                    <a
+                                        class="nav-link {{ app.request.attributes.get('_route') == 'messages:auto' ? 'active' }}"
+                                        id="nav-automatic-messages-tab"
+                                        href="{{ path('messages:auto') }}"
+                                        role="tab"
+                                        aria-selected="{{ app.request.attributes.get('_route') == 'messages:auto' ? 'true' : 'false' }}">
+                                        Messages rapides
+                                    </a>
+                                    <a
+                                        class="nav-link {{ app.request.attributes.get('_route') == 'messages:error' ? 'active' }}"
+                                        id="nav-error-details-tab"
+                                        href="{{ path('messages:error') }}"
+                                        role="tab"
+                                        aria-selected="{{ app.request.attributes.get('_route') == 'messages:error' ? 'true' : 'false' }}">
+                                        Détails erreur
+                                    </a>
+                                    <a
+                                        class="nav-link {{ app.request.attributes.get('_route') == 'messages:addonpack' ? 'active' }}"
+                                        id="nav-addonpack-tab"
+                                        href="{{ path('messages:addonpack') }}"
+                                        role="tab"
+                                        aria-selected="{{ app.request.attributes.get('_route') == 'messages:addonpack' ? 'true' : 'false' }}">
+                                        Packs d'add-ons
+                                    </a>
+                                </div>
+                            </div>
+                            <div class="col-lg-10 align-self-center">
+                                <div class="tab-content">
+                                    <div class="tab-pane show active">
+                                        {% if messages|length > 0 %}
+                                            <div class="table-responsive">
+                                                <table class="table">
+                                                    <thead>
+                                                        <tr>
+                                                            <th scope="col">Nom</th>
+                                                            <th scope="col">Aliases</th>
+                                                            <th scope="col">Aperçu du contenu</th>
+                                                            <th scope="col">Actions</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        {% for message in messages %}
+                                                            <tr>
+                                                                <td>
+                                                                    {{ message.name }}
+                                                                </td>
+                                                                <td>
+                                                                    {{ message.aliases|join(', ') }}
+                                                                </td>
+                                                                <td>
+                                                                    {{ message.content|truncate }}
+                                                                </td>
+                                                                <td>
+                                                                    <a href="{{ path('messages:edit', { messageId: message.id }) }}" type="button" class="btn btn-info"><i class="fas fa-edit"></i></a>
+                                                                </td>
+                                                            </tr>
+                                                        {% endfor %}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        {% else %}
+                                            <p class="text-center">
+                                                Aucun de ces messages n'a été créé pour le moment !
+                                            </p>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
                             {{ knp_pagination_render(messages) }}
                         </div>
                     </div>

--- a/templates/messages/new.html.twig
+++ b/templates/messages/new.html.twig
@@ -25,7 +25,7 @@
                                 </div>
                             </div>
                             <div class="mb-3">
-                                <button type="button" id="addAliasButton" class="btn btn-sm btn-success">
+                                <button id="addAliasButton" class="btn btn-sm btn-success">
                                     <i class="fas fa-plus"></i> Ajouter un alias
                                 </button>
                             </div>

--- a/templates/messages/new.html.twig
+++ b/templates/messages/new.html.twig
@@ -17,7 +17,7 @@
                                 <div class="input-group-prepend">
                                     <span class="input-group-text">Nom</span>
                                 </div>
-                                <input type="text" class="form-control" aria-label="Nom" aria-describedby="name" id="name" name="name" onchange="generateDiff()">
+                                <input type="text" class="form-control" aria-label="Nom" aria-describedby="name" id="name" name="name" onkeyup="generateDiff()">
                             </div>
                             <div class="dropdown-divider mb-3"></div>
                             <div> {# Don't remove this empty node #}
@@ -80,13 +80,8 @@
                     });
                 });
 
-                document.querySelectorAll('.link-remove').forEach((el) => el.addEventListener('click', () => {
-                    const element = el.parentNode.parentNode;
-                    element.parentNode.removeChild(element);
-                }));
-
                 document.getElementById('addAliasButton').addEventListener('click', () => {
-                    const input = '<div class="input-group"> <input type="text" class="form-control" name="aliases[{index}]" onchange="generateDiff()" <div class="input-group-append"> <button class="btn btn-outline-danger link-remove" type="button"> <i class="fas fa-times"></i> </button> </div> </div>'
+                    const input = '<div class="input-group"> <input type="text" class="form-control" name="aliases[{index}]" onkeyup="generateDiff()" <div class="input-group-append"> <button class="btn btn-outline-danger link-remove" type="button"> <i class="fas fa-times"></i> </button> </div> </div>'
                     const newElement = document.createElement('div');
 
                     newElement.className = 'form-group mr-2';
@@ -98,6 +93,8 @@
                     linkRemove.addEventListener('click', () => {
                         const element = linkRemove.parentNode.parentNode;
                         element.parentNode.removeChild(element);
+
+                        generateDiff();
                     });
 
                 });
@@ -119,7 +116,6 @@
                 }
 
                 generateDiff();
-
             </script>
         </form>
     </div>

--- a/templates/messages/view.html.twig
+++ b/templates/messages/view.html.twig
@@ -27,7 +27,7 @@
                                     <div class="input-group">
                                         <input type="text" class="form-control" name="aliases[{index}]" value="{{ alias }}" onchange="generateDiff()" disabled>
                                         <div class="input-group-append">
-                                            <button class="btn btn-outline-danger link-remove" type="button" disabled>
+                                            <button class="btn btn-outline-danger link-remove" disabled>
                                                 <i class="fas fa-times"></i>
                                             </button>
                                         </div>
@@ -36,7 +36,7 @@
                             {% endfor %}
                         </div>
                         <div class="mb-3">
-                            <button type="button" id="addAliasButton" class="btn btn-sm btn-success" disabled>
+                            <button id="addAliasButton" class="btn btn-sm btn-success" disabled>
                                 <i class="fas fa-plus"></i> Ajouter un alias
                             </button>
                         </div>

--- a/templates/users/home.html.twig
+++ b/templates/users/home.html.twig
@@ -32,7 +32,7 @@
                                     {% endfor %}
                                 </td>
                                 <td>{{ user.id }}</td>
-                                <td><a href="/users/{{ user.id }}" type="button" class="btn btn-info"><i class="fas fa-user-edit"></i></a></td>
+                                <td><a href="/users/{{ user.id }}" class="btn btn-info"><i class="fas fa-user-edit"></i></a></td>
                             </tr>
                         {% endfor %}
                         </tbody>


### PR DESCRIPTION
Fix the buttons on Safari. I also tried on Firefox, which was already working, and nothing has changed: still good.
Basically, what I've done is remove the `type="button"`from all buttons/anchors.

## Before
![image](https://user-images.githubusercontent.com/34779161/104937731-69d9e000-59ae-11eb-8f60-31e1cf06f41c.png)
## After
![image](https://user-images.githubusercontent.com/34779161/104937765-73fbde80-59ae-11eb-90e0-9874c1bec3d0.png)


*Idk why it has included my previous commits, I'm really struggling with keeping my fork up to date with upstream, idk why 😂*